### PR TITLE
Update combat-trainer.lic

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -2459,13 +2459,16 @@ class AttackProcess
 
     @stealth_attack_aimed_action = settings.stealth_attack_aimed_action
     echo("  @stealth_attack_aimed_action: #{@stealth_attack_aimed_action}") if $debug_mode_ct
-
+   
+   	@use_stealth_ranged = settings.use_stealth_ranged #new
+    echo("  @use_stealth_ranged: #{@use_stealth_ranged}") if $debug_mode_ct
+    
     @hide_type = settings.hide_type
     echo("  @hide_type: #{@hide_type}") if $debug_mode_ct
 
     @offhand_thrown = settings.offhand_thrown
     echo("  @offhand_thrown: #{@offhand_thrown}") if $debug_mode_ct
-
+    
     @ambush_location = settings.ambush_location
     echo("  @ambush_location: #{@ambush_location}") if $debug_mode_ct
 
@@ -2643,7 +2646,7 @@ class AttackProcess
         use_charged_maneuver(game_state.selected_maneuver, game_state)
         game_state.action_taken
       else
-        command = if game_state.use_stealth_attack? && hide?(@hide_type)
+        command = if game_state.use_stealth_ranged? && hide?(@hide_type)
                     @stealth_attack_aimed_action
                   else
                     'shoot'
@@ -3348,6 +3351,10 @@ class GameState
 
   def backstab?
     @backstab.include?(weapon_skill) && DRSkill.getxp('Backstab') < 34
+  end
+  
+  def use_stealth_ranged? #new
+    @use_stealth_ranged && use_stealth? #new
   end
 
   def dancing?


### PR DESCRIPTION
Separates using stealth attacks, so that you can use snipe without using ambush and backstab.  very useful to keep stealth moving(snipe/poach will teach stealth beyond ambush/backstab), but keeps weapons moving well